### PR TITLE
Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Validate CLAUDE.md
               run: npx claude-code-lint@latest
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '18'
                   cache: 'npm'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Summary

Migrates workflows off Node 20-runtime actions ahead of GitHub's **June 2, 2026** runner cutover.

## Changes

- \`actions/checkout\` v4 → **v6**
- \`actions/setup-node\` v4 → **v6**
- \`dependabot/fetch-metadata\` v2 → **v3**

## Out of scope

\`package.json\` engines.node is "18.x". Node 18 has been EOL since April 2025. Bumping should happen alongside CI \`node-version\` and any deploy-target bumps — separate from this Node 24 actions migration.

## Also enabled on this repo

- Secret scanning + push protection (free for public repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)