### PR TITLE
docs: standardize readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Hikearound Web
+# hikearound-web
 
-[![CI](https://github.com/hikearound/hikearound-web/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/hikearound/hikearound-web/actions/workflows/ci.yml)
-[![Next.js](https://img.shields.io/badge/Next.js-12-000000?logo=nextdotjs&logoColor=white)](https://nextjs.org)
-[![React](https://img.shields.io/badge/React-17-61DAFB?logo=react&logoColor=white)](https://reactjs.org)
-[![License: ISC](https://img.shields.io/badge/License-ISC-blue?logo=opensourceinitiative&logoColor=white)](LICENSE)
+[![CI](https://github.com/hikearound/hikearound-web/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/hikearound/hikearound-web/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/hikearound/hikearound-web)](LICENSE)
 
 A Next.js web app for discovering and sharing curated hiking trails. Server-rendered hike pages with SEO metadata, Algolia search, and Apple MapKit integration; backed by Firebase and instrumented with Sentry.
 


### PR DESCRIPTION
## What changed

- normalize the H1 to the exact lowercase repository slug
- keep native GitHub CI scoped to master push runs
- remove decorative Next.js and React badges
- replace the stale static ISC badge with GitHub's detected MIT license badge

## Why

This is the web-application canary for the evidence-backed fleet README convention: applications should show delivery and licensing signals without inventorying their implementation stack.

## Verification

- changed path is exactly `README.md`
- README body is byte-for-byte unchanged after the title/badge block
- `git diff --check` passes
- both proposed badge endpoints return HTTP 200 with CI passing and MIT detected
- no source, package, workflow, settings, or deployment changes
